### PR TITLE
feat: Add functionality to dynamically add records via map popup

### DIFF
--- a/mapper/static/mapper/js/map_add.js
+++ b/mapper/static/mapper/js/map_add.js
@@ -23,19 +23,95 @@ document.addEventListener('DOMContentLoaded', function () {
             const { lat, lng } = e.latlng; // Get clicked coordinates
             console.log(`🟢 Location selected: Latitude ${lat}, Longitude ${lng}`);
 
-            // Optionally, add a marker at the clicked location
-            const marker = L.marker([lat, lng]).addTo(map);
-            marker.bindPopup('New Record Location').openPopup();
+            // Limit latitude and longitude to 6 decimal places
+            const latitude = lat.toFixed(6);
+            const longitude = lng.toFixed(6);
 
-            // Restore default cursor and exit "add record" mode
-            map.getContainer().style.cursor = '';
-            isAddingRecord = false;
+            // Fetch record types and deaneries dynamically
+            fetch('/mapper/get-dropdown-options/')
+                .then(response => response.json())
+                .then(data => {
+                    const recordTypeOptions = data.record_types
+                        .map(type => `<option value="${type}">${type}</option>`)
+                        .join('');
+                    const deaneryOptions = data.deaneries
+                        .map(deanery => `<option value="${deanery}">${deanery}</option>`)
+                        .join('');
 
-            // Enable the add record button
-            addRecordBtn.disabled = false;
+                    // Create a popup with a form
+                    const popupContent = `
+                        <form id="add-record-form">
+                            <label for="name">Name:</label>
+                            <input type="text" id="name" name="name" required><br>
+                            
+                            <label for="record_type">Record Type:</label>
+                            <select id="record_type" name="record_type" required>
+                                ${recordTypeOptions}
+                            </select><br>
+                            
+                            <label for="deanery">Deanery:</label>
+                            <select id="deanery" name="deanery" required>
+                                ${deaneryOptions}
+                            </select><br>
+                            
+                            <label for="latitude">Latitude:</label>
+                            <input type="text" id="latitude" name="latitude" value="${latitude}" readonly><br>
+                            
+                            <label for="longitude">Longitude:</label>
+                            <input type="text" id="longitude" name="longitude" value="${longitude}" readonly><br>
+                            
+                            <button type="submit">Add Record</button>
+                        </form>
+                    `;
 
-            // Open a modal to add record details (optional)
-            openAddRecordModal(lat, lng);
+                    const popup = L.popup()
+                        .setLatLng([latitude, longitude])
+                        .setContent(popupContent)
+                        .openOn(map);
+
+                    // Handle form submission
+                    const form = document.getElementById('add-record-form');
+                    form.addEventListener('submit', function (event) {
+                        event.preventDefault(); // Prevent default form submission
+
+                        const formData = new FormData(form);
+
+                        // Send data to the backend
+                        fetch('/mapper/add-record/', {
+                            method: 'POST',
+                            headers: {
+                                'X-CSRFToken': getCsrfToken(), // Include CSRF token
+                            },
+                            body: formData,
+                        })
+                            .then(response => response.json())
+                            .then(data => {
+                                if (data.success) {
+                                    console.log('🟢 Record added successfully:', data);
+
+                                    // Add a marker for the new record
+                                    const newMarker = L.marker([latitude, longitude]).addTo(map);
+                                    newMarker.bindPopup(`<b>${data.record.name}</b><br>${data.record.record_type}`).openPopup();
+
+                                    // Exit "add record" mode
+                                    map.getContainer().style.cursor = '';
+                                    isAddingRecord = false;
+                                    addRecordBtn.disabled = false;
+                                } else {
+                                    console.error('🔴 Error adding record:', data.errors);
+                                    alert('Failed to add record. Please try again.');
+                                }
+                            })
+                            .catch(error => {
+                                console.error('🔴 Error:', error);
+                                alert('An error occurred. Please try again.');
+                            });
+                    });
+                })
+                .catch(error => {
+                    console.error('🔴 Error fetching dropdown options:', error);
+                    alert('Failed to fetch dropdown options. Please try again.');
+                });
         }
     });
 
@@ -50,8 +126,8 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 
-// Function to open a modal for adding a new record
-function openAddRecordModal(lat, lng) {
-    console.log(`🟢 Opening modal for new record at Latitude ${lat}, Longitude ${lng}`);
-    // Implement modal logic here (e.g., fetch modal content or display a form)
+// Function to get CSRF token from cookies
+function getCsrfToken() {
+    const csrfCookie = document.cookie.split('; ').find(row => row.startsWith('csrftoken='));
+    return csrfCookie ? csrfCookie.split('=')[1] : '';
 }

--- a/mapper/urls.py
+++ b/mapper/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 from . import views
 from .views import (
     crud_modal,
+    add_record,
+    get_dropdown_options,
 )
 
 urlpatterns = [
@@ -22,4 +24,6 @@ urlpatterns = [
         views.update_record,
         name='update_record'
     ),
+    path('add-record/', add_record, name='add_record'),
+    path('get-dropdown-options/', get_dropdown_options, name='get_dropdown_options'),
 ]

--- a/valor_records/models/valor_record.py
+++ b/valor_records/models/valor_record.py
@@ -15,22 +15,22 @@ class ValorRecord(models.Model):
     ]
 
     # General
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)  # Required
     slug = models.SlugField(unique=True, blank=True)
     record_type = models.ForeignKey(
         RecordType,
         on_delete=models.CASCADE,
         related_name='valor_records'
-    )
+    )  # Required
     dedication = models.CharField(blank=True, max_length=255, null=True)
     deanery = models.ForeignKey(
         Deanery,
         on_delete=models.CASCADE,
         related_name='valor_records'
-    )
+    )  # Required
     status = models.CharField(
         max_length=10, choices=STATUS_CHOICES, default='pending'
-    )
+    )  # Required
 
     # Monastic
     house_type = models.ForeignKey(


### PR DESCRIPTION
- Implemented "Add Record" mode in the map interface.
- Added a popup form to capture user input for name, record type, deanery, latitude, and longitude.
- Dynamically fetch dropdown options for record type and deanery from the backend.
- Created a new backend endpoint (`get_dropdown_options`) to provide dropdown data.
- Added a backend endpoint (`add_record`) to handle record creation with status set to "Approved".
- Updated the map to display a marker for newly added records.
- Improved error handling for invalid input or server errors.